### PR TITLE
update viewer behavior when workflow is empty

### DIFF
--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -13,7 +13,7 @@
     </v-navigation-drawer>
     <v-layout justify-end>
       <v-btn id="yaml-button" v-on:click="switchDrawer" :disabled="yamlForHTML.length === 0">
-        <span>{{ state.viewer.drawer ? 'view yaml' : 'hide yaml'}}</span>
+        <span>{{state.viewer.drawer ? 'view yaml' : 'hide yaml'}}</span>
       </v-btn>
     </v-layout>
   </div>

--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -13,7 +13,7 @@
     </v-navigation-drawer>
     <v-layout justify-end>
       <v-btn id="yaml-button" v-on:click="switchDrawer" :disabled="yamlForHTML.length === 0">
-        <span>{{ state.viewer.drawer ? 'view yaml' : 'hide yaml' }}</span>
+        <span>{{ state.viewer.drawer ? 'view yaml' : 'hide yaml'}}</span>
       </v-btn>
     </v-layout>
   </div>
@@ -37,19 +37,21 @@ export default {
   methods: {
     switchDrawer () {
       let nextState = !this.stateService.currentViewerState.drawer
-      this.stateService.setViewerDrawerOpen(nextState)
+      this.stateService.setViewerDrawerClosed(nextState)
     },
     copyToClipboard () {
       window.getSelection().selectAllChildren(document.getElementById('yaml-text'))
       document.execCommand('copy')
     },
     yaml () {
-      this.stateService.setViewerDirty(false)
-      return this.generatorService.generate(
+      const yaml = this.generatorService.generate(
         this.stateService.currentWorkflow,
-        this.jsPlumbService.getAllConnections(this.stateService.currentWorkflow),
-        this.state.viewer.viewerDirty
+        this.jsPlumbService.getAllConnections(this.stateService.currentWorkflow)
       )
+      if (!this.stateService.currentViewerState.drawer) {
+        this.stateService.setViewerDrawerClosed(!yaml)
+      }
+      return yaml
     },
     downloadYaml (filename) {
       const file = new Blob([this.yaml()], {type: 'application/x-yaml;charset=utf-8'})

--- a/src/services/state_service.js
+++ b/src/services/state_service.js
@@ -35,8 +35,8 @@ export default class StateService {
   setDrawerOpen (open) {
     this.state.navigator.drawer = open
   }
-  setViewerDrawerOpen (open) {
-    this.state.viewer.drawer = open
+  setViewerDrawerClosed (close) {
+    this.state.viewer.drawer = close
   }
 
   get currentWorkflow () {


### PR DESCRIPTION
update viewer behavior when workflow is empty 
The navigation drawer closes when the workflows becomes empty